### PR TITLE
Added support for multiple referenced backref fields and improved backref query

### DIFF
--- a/demo/demo-data.json
+++ b/demo/demo-data.json
@@ -82,7 +82,7 @@
         {
           "id": "author",
           "type": "Array<Link<Entry>>",
-          "linkedCt": "1kUEViTN4EmGiEaaeC6ouY"
+          "linkedCts": ["1kUEViTN4EmGiEaaeC6ouY"]
         },
         {
           "id": "body",
@@ -91,7 +91,7 @@
         {
           "id": "category",
           "type": "Array<Link<Entry>>",
-          "linkedCt": "5KMiN6YPvi42icqAUQMCQe"
+          "linkedCts": ["5KMiN6YPvi42icqAUQMCQe"]
         },
         {
           "id": "tags",

--- a/src/backref-types.js
+++ b/src/backref-types.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _get = require('lodash.get');
-const {GraphQLObjectType, GraphQLList} = require('graphql');
+const {GraphQLString, GraphQLInt, GraphQLObjectType, GraphQLList} = require('graphql');
 
 module.exports = createBackrefsType;
 
@@ -25,9 +25,20 @@ function prepareBackrefsFields (ct, ctIdToType) {
 function createBackrefFieldConfig (backref, Type) {
   return {
     type: new GraphQLList(Type),
-    resolve: (entryId, _, ctx) => {
-      return ctx.entryLoader.queryAll(backref.ctId)
-      .then(entries => filterEntries(entries, backref.fieldId, entryId));
+    args: {
+      q: {type: GraphQLString},
+      skip: {type: GraphQLInt},
+      limit: {type: GraphQLInt},
+    },
+    resolve: (entryId, args, ctx) => {
+      let q = `fields.${backref.fieldId}.sys.id[in]=${entryId}`;
+      if (args.q) q = q + `&${args.q}`;
+
+      return ctx.entryLoader.query(backref.ctId, {
+        q,
+        skip: args.skip,
+        limit: args.limit,
+      })
     }
   };
 }

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -75,7 +75,7 @@ function createEntryFieldConfig (field, ctIdToType) {
   return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx) => {
     const linkedId = getLinkedId(link);
     if (isString(linkedId)) {
-      return ctx.entryLoader.get(linkedId, field.linkedCt);
+      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0]);
     }
   });
 }
@@ -95,9 +95,9 @@ function getLinkedId (link) {
   return _get(link, ['sys', 'id']);
 }
 
-function typeFor ({linkedCt}, ctIdToType = {}) {
-  if (linkedCt) {
-    return ctIdToType[linkedCt] || EntryType;
+function typeFor ({linkedCts}, ctIdToType = {}) {
+  if (linkedCts && linkedCts[0]) {
+    return ctIdToType[linkedCts[0]] || EntryType;
   } else {
     return EntryType;
   }

--- a/src/prepare-space-graph.js
+++ b/src/prepare-space-graph.js
@@ -82,7 +82,7 @@ function field (f) {
   return {
     id: f.id,
     type: type(f),
-    linkedCt: linkedCt(f)
+    linkedCts: linkedCts(f)
   };
 }
 
@@ -117,15 +117,15 @@ function isEntityType (x) {
   return ENTITY_TYPES.indexOf(x) > -1;
 }
 
-function linkedCt (f) {
+function linkedCts (f) {
   const prop = 'linkContentType';
   const validation = getValidations(f).find(v => {
-    return Array.isArray(v[prop]) && v[prop].length === 1;
+    return Array.isArray(v[prop]);
   });
-  const linkedCt = validation && validation[prop][0];
+  const linkedCts = validation && validation[prop];
 
-  if (linkedCt) {
-    return linkedCt;
+  if (linkedCts) {
+    return linkedCts;
   }
 }
 
@@ -144,15 +144,16 @@ function addBackrefs (spaceGraph) {
   }, {});
 
   spaceGraph.forEach(ct => ct.fields.forEach(field => {
-    if (field.linkedCt && byId[field.linkedCt]) {
-      const linked = byId[field.linkedCt];
+    if (field.linkedCts) field.linkedCts.forEach(linkedCt => {
+      const linked = byId[linkedCt];
+      if (!linked) return;
       linked.backrefs = linked.backrefs || [];
       linked.backrefs.push({
         ctId: ct.id,
         fieldId: field.id,
-        backrefFieldName: `${ct.names.collectionField}__via__${field.id}`
+        backrefFieldName: `${ct.names.collectionField}__via__${field.id}`,
       });
-    }
+    });
   }));
 
   return spaceGraph;

--- a/test/field-config.test.js
+++ b/test/field-config.test.js
@@ -121,12 +121,12 @@ test('field-config: type for linked entry', function (t) {
   const types = {ct1: {}, ct2: {}};
   const tests = [
     [{}, undefined, EntryType],
-    [{linkedCt: 'ct1'}, undefined, EntryType],
-    [{linkedCt: 'ct2'}, {ct1: types.ct1, ct2: types.ct2}, types.ct2],
-    [{linkedCt: 'ct3'}, {ct1: types.ct1, ct2: types.ct2}, EntryType]
+    [{linkedCts: ['ct1']}, undefined, EntryType],
+    [{linkedCts: ['ct2']}, {ct1: types.ct1, ct2: types.ct2}, types.ct2],
+    [{linkedCts: ['ct3']}, {ct1: types.ct1, ct2: types.ct2}, EntryType]
   ];
 
-  tests.forEach(([field, ctIdToType, Type]) => {
+  tests.forEach(([field, ctIdToType, Type], i) => {
     const config = map['Link<Entry>'](field, ctIdToType);
     t.equal(config.type, Type);
   });

--- a/test/prepare-space-graph.test.js
+++ b/test/prepare-space-graph.test.js
@@ -2,6 +2,7 @@
 
 const test = require('tape');
 
+const flatmap = require('lodash/flatmap');
 const prepareSpaceGraph = require('../src/prepare-space-graph.js');
 
 const testCt = fields => ({sys: {id: 'ctid'}, name: 'test', fields});
@@ -155,9 +156,9 @@ test('prepare-space-graph: finding linked content types', function (t) {
   }, []);
 
   const [p] = prepareSpaceGraph([testCt(fields)]);
-  const linkedCts = p.fields.map(f => f.linkedCt).filter(id => typeof id === 'string');
+  const linkedCts = flatmap(p.fields, f => f.linkedCts).filter(id => typeof id === 'string');
 
-  t.deepEqual(linkedCts, ['baz', 'baz']);
+  t.deepEqual(linkedCts, ['foo', 'bar', 'foo', 'bar', 'baz', 'baz']);
 
   t.end();
 });
@@ -167,7 +168,7 @@ test('prepare-space-graph: mixing field and items validations', function (t) {
   const fields = [{id: 'fid', type: 'Array', validations: [], items}];
   const [p] = prepareSpaceGraph([testCt(fields)]);
 
-  t.equal(p.fields[0].linkedCt, 'ctid');
+  t.equal(p.fields[0].linkedCts[0], 'ctid');
 
   t.end();
 });

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -25,7 +25,7 @@ const postct = {
   fields: [
     {id: 'title', type: 'String'},
     {id: 'content', type: 'String'},
-    {id: 'category', type: 'Link<Entry>', linkedCt: 'catct'}
+    {id: 'category', type: 'Link<Entry>', linkedCts: ['catct']}
   ]
 };
 
@@ -113,11 +113,11 @@ test('schema: querying generated schema', function (t) {
 
   testQuery(
     '{ categories { _backrefs { posts__via__category { title } } } }',
-    {query: sinon.stub().resolves([category]), queryAll: sinon.stub().resolves([post])}
+    {query: sinon.stub().onCall(0).resolves([category]).onCall(1).resolves([post])}
   ).then(([entryLoader, res]) => {
-    t.deepEqual(entryLoader.query.firstCall.args, ['catct', {}]);
-    t.deepEqual(entryLoader.queryAll.firstCall.args, ['postct']);
     t.equal(res.errors, undefined);
+    t.deepEqual(entryLoader.query.firstCall.args, ['catct', {}]);
+    t.deepEqual(entryLoader.query.lastCall.args[0], 'postct');
     t.deepEqual(res.data, {categories: [{_backrefs: {posts__via__category: [{title: 'Hello world'}]}}]});
   });
 


### PR DESCRIPTION
This commit adds support for:

- Backrefs for multiple validated fields (eg, retailCategories, retailSubCategories)
- Passing query strings to backref requests. Eg, `_backrefs { stores__via__centre(q) {...} }`

It also improves the backref query support, removing the client-side filter and instead sending the query to contentful.