### PR TITLE
Move graphql back to a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "dataloader": "^1.3.0",
+    "graphql": "^0.13.0",
     "https-proxy-agent": "^2.1.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.chunk": "^4.2.0",
@@ -65,7 +66,6 @@
     "express": "^4.15.4",
     "express-graphql": "^0.6.7",
     "fetch-graphql-schema": "^0.2.1",
-    "graphql": "^0.13.0",
     "graphqlviz": "^2.0.1",
     "istanbul": "^0.4.5",
     "just-extend": "1.1.22",


### PR DESCRIPTION
… keeping it at 0.13, because that seems to be fine?