### PR TITLE
Only get Selected fields for 'query' calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /coverage
 /dump
 /dev/config.json
+.idea
+yarn.lock
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea
 yarn.lock
 package-lock.json
+.DS_store

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "dataloader": "^1.3.0",
+    "graphql-fields": "^1.0.2",
     "https-proxy-agent": "^2.1.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.chunk": "^4.2.0",

--- a/src/backref-types.js
+++ b/src/backref-types.js
@@ -30,15 +30,18 @@ function createBackrefFieldConfig (backref, Type) {
       skip: {type: GraphQLInt},
       limit: {type: GraphQLInt},
     },
-    resolve: (entryId, args, ctx) => {
+    resolve: (entryId, args, ctx, info) => {
       let q = `fields.${backref.fieldId}.sys.id[in]=${entryId}`;
       if (args.q) q = q + `&${args.q}`;
 
-      return ctx.entryLoader.query(backref.ctId, {
-        q,
-        skip: args.skip,
-        limit: args.limit,
-      })
+      return ctx.entryLoader.query(
+        backref.ctId, {
+          q,
+          skip: args.skip,
+          limit: args.limit,
+        },
+        info
+      );
     }
   };
 }

--- a/src/entry-loader.js
+++ b/src/entry-loader.js
@@ -21,7 +21,7 @@ const getSelectedFields = info => {
     return null;
   }
   const topLevelFields = Object.keys(graphqlFields(info)).filter(key => key !== 'sys');
-  if (topLevelFields.length > MAX_FIELDS) {
+  if (topLevelFields.length < 1 || topLevelFields.length > MAX_FIELDS) {
     // There is a limit to the number of fields we can select. If too many get everything
     return null;
   }

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -35,10 +35,10 @@ module.exports = {
 function createFieldConfig (Type, field, resolveFn) {
   return {
     type: Type,
-    resolve: (entity, _, ctx) => {
+    resolve: (entity, _, ctx, info) => {
       const fieldValue = _get(entity, ['fields', field.id], NOTHING);
       if (fieldValue !== NOTHING) {
-        return resolveFn ? resolveFn(fieldValue, ctx) : fieldValue;
+        return resolveFn ? resolveFn(fieldValue, ctx, info) : fieldValue;
       }
     }
   };
@@ -72,10 +72,10 @@ function getAsset (link, ctx) {
 }
 
 function createEntryFieldConfig (field, ctIdToType) {
-  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx) => {
+  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx, info) => {
     const linkedId = getLinkedId(link);
     if (isString(linkedId)) {
-      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0]);
+      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0], info);
     }
   });
 }

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -72,10 +72,10 @@ function getAsset (link, ctx) {
 }
 
 function createEntryFieldConfig (field, ctIdToType) {
-  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx, info) => {
+  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx) => {
     const linkedId = getLinkedId(link);
     if (isString(linkedId)) {
-      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0], info);
+      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0]);
     }
   });
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -76,10 +76,10 @@ function createQueryFields (spaceGraph) {
         ids: {type: new GraphQLList(IDType)},
       },
       resolve: (_, args, ctx, info) => {
-        const { ids } = args;
+        const {ids} = args;
         if (ids) {
           return ctx.entryLoader.getMany(ids, info)
-          .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id));
+          .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id))
         } else {
           return ctx.entryLoader.query(ct.id, args, info);
         }

--- a/src/schema.js
+++ b/src/schema.js
@@ -76,12 +76,12 @@ function createQueryFields (spaceGraph) {
         ids: {type: new GraphQLList(IDType)},
       },
       resolve: (_, args, ctx, info) => {
-        const {ids} = args
+        const { ids } = args;
         if (ids) {
           return ctx.entryLoader.getMany(ids, info)
-          .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id))
+          .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id));
         } else {
-          return ctx.entryLoader.query(ct.id, args, info)
+          return ctx.entryLoader.query(ct.id, args, info);
         }
       }
     };

--- a/src/schema.js
+++ b/src/schema.js
@@ -64,7 +64,7 @@ function createQueryFields (spaceGraph) {
     acc[ct.names.field] = {
       type: Type,
       args: {id: {type: IDType}},
-      resolve: (_, args, ctx, info) => ctx.entryLoader.get(args.id, ct.id, info)
+      resolve: (_, args, ctx) => ctx.entryLoader.get(args.id, ct.id)
     };
 
     acc[ct.names.collectionField] = {

--- a/src/schema.js
+++ b/src/schema.js
@@ -64,7 +64,7 @@ function createQueryFields (spaceGraph) {
     acc[ct.names.field] = {
       type: Type,
       args: {id: {type: IDType}},
-      resolve: (_, args, ctx) => ctx.entryLoader.get(args.id, ct.id)
+      resolve: (_, args, ctx, info) => ctx.entryLoader.get(args.id, ct.id, info)
     };
 
     acc[ct.names.collectionField] = {
@@ -75,13 +75,13 @@ function createQueryFields (spaceGraph) {
         limit: {type: GraphQLInt},
         ids: {type: new GraphQLList(IDType)},
       },
-      resolve: (_, args, ctx) => {
+      resolve: (_, args, ctx, info) => {
         const {ids} = args
         if (ids) {
-          return ctx.entryLoader.getMany(ids)
+          return ctx.entryLoader.getMany(ids, info)
           .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id))
         } else {
-          return ctx.entryLoader.query(ct.id, args)
+          return ctx.entryLoader.query(ct.id, args, info)
         }
       }
     };

--- a/test/entry-loader.test.js
+++ b/test/entry-loader.test.js
@@ -65,6 +65,63 @@ test('entry-loader: querying entries', function (t) {
   });
 });
 
+test('entry-loader: querying entries with resolve Info', function (t) {
+  t.plan(3);
+  const {httpStub, loader} = prepare();
+  const resolveInfo = {
+    fieldNodes: [{
+      selectionSet: {
+        selections: [
+          { name: { value: 'title' } },
+          { name: { value: 'slug' } },
+        ]
+      }
+    }],
+  };
+  loader.query('ctid', {q: 'fields.someNum=123&fields.test[exists]=true'}, resolveInfo)
+  .then(res => {
+    t.deepEqual(res, ITEMS);
+    t.equal(httpStub.get.callCount, 1);
+    t.deepEqual(httpStub.get.lastCall.args, ['/entries', {
+      skip: 0,
+      limit: 50,
+      include: 1,
+      content_type: 'ctid',
+      'fields.someNum': '123',
+      'fields.test[exists]': 'true',
+      select: 'sys,fields.title,fields.slug',
+    }]);
+  });
+});
+
+test('entry-loader: querying entries with only sys field requested', function (t) {
+  t.plan(3);
+  const {httpStub, loader} = prepare();
+  const resolveInfo = {
+    fieldNodes: [{
+      selectionSet: {
+        selections: [
+          { name: { value: 'sys' } },
+          { name: { value: '__typename' } },
+        ]
+      }
+    }],
+  };
+  loader.query('ctid', {q: 'fields.someNum=123&fields.test[exists]=true'}, resolveInfo)
+  .then(res => {
+    t.deepEqual(res, ITEMS);
+    t.equal(httpStub.get.callCount, 1);
+    t.deepEqual(httpStub.get.lastCall.args, ['/entries', {
+      skip: 0,
+      limit: 50,
+      include: 1,
+      content_type: 'ctid',
+      'fields.someNum': '123',
+      'fields.test[exists]': 'true',
+    }]);
+  });
+});
+
 test('entry-loader: counting entries', function (t) {
   t.plan(3);
   const {httpStub, loader} = prepare();

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -8,6 +8,7 @@ const {
   GraphQLSchema,
   GraphQLObjectType
 } = require('graphql');
+const graphqlFields = require('graphql-fields');
 
 const {
   createSchema,
@@ -69,11 +70,13 @@ test('schema: querying generated schema', function (t) {
     .then(res => [entryLoader, res]);
   };
 
-  t.plan(22);
+  t.plan(30);
 
   testQuery('{ posts { title } }', {query: sinon.stub().resolves([post])})
   .then(([entryLoader, res]) => {
-    t.deepEqual(entryLoader.query.firstCall.args, ['postct', {}]);
+    t.deepEqual(entryLoader.query.firstCall.args[0], 'postct');
+    t.deepEqual(entryLoader.query.firstCall.args[1], {});
+    t.deepEqual(graphqlFields(entryLoader.query.firstCall.args[2]), { title: {} });
     t.equal(res.errors, undefined);
     t.deepEqual(res.data.posts, [{title: 'Hello world'}]);
   });
@@ -82,10 +85,12 @@ test('schema: querying generated schema', function (t) {
     '{ categories(skip: 2, limit: 3, q: "fields.name=test") { name } }',
     {query: sinon.stub().resolves([category])}
   ).then(([entryLoader, res]) => {
+    t.deepEqual(entryLoader.query.firstCall.args[0], 'catct');
     t.deepEqual(
-      entryLoader.query.firstCall.args,
-      ['catct', {skip: 2, limit: 3, q: 'fields.name=test'}]
+      entryLoader.query.firstCall.args[1],
+      {skip: 2, limit: 3, q: 'fields.name=test'}
     );
+    t.deepEqual(graphqlFields(entryLoader.query.firstCall.args[2]), { name: {} });
     t.equal(res.errors, undefined);
     t.deepEqual(res.data.categories, [{name: 'test'}]);
   });
@@ -105,7 +110,9 @@ test('schema: querying generated schema', function (t) {
     '{ posts { title } category(id: "c1") { name } }',
     {query: sinon.stub().resolves([post]), get: sinon.stub().resolves(category)}
   ).then(([entryLoader, res]) => {
-    t.deepEqual(entryLoader.query.firstCall.args, ['postct', {}]);
+    t.deepEqual(entryLoader.query.firstCall.args[0], 'postct');
+    t.deepEqual(entryLoader.query.firstCall.args[1], {});
+    t.deepEqual(graphqlFields(entryLoader.query.firstCall.args[2]), { title: {} });
     t.deepEqual(entryLoader.get.firstCall.args, ['c1', 'catct']);
     t.equal(res.errors, undefined);
     t.deepEqual(res.data, {posts: [{title: 'Hello world'}], category: {name: 'test'}});
@@ -116,7 +123,18 @@ test('schema: querying generated schema', function (t) {
     {query: sinon.stub().onCall(0).resolves([category]).onCall(1).resolves([post])}
   ).then(([entryLoader, res]) => {
     t.equal(res.errors, undefined);
-    t.deepEqual(entryLoader.query.firstCall.args, ['catct', {}]);
+    t.deepEqual(entryLoader.query.firstCall.args[0], 'catct');
+    t.deepEqual(entryLoader.query.firstCall.args[1], {});
+    t.deepEqual(
+      graphqlFields(entryLoader.query.firstCall.args[2]),
+      {
+        _backrefs: {
+          posts__via__category: {
+            title: {},
+          },
+        },
+      }
+    );
     t.deepEqual(entryLoader.query.lastCall.args[0], 'postct');
     t.deepEqual(res.data, {categories: [{_backrefs: {posts__via__category: [{title: 'Hello world'}]}}]});
   });


### PR DESCRIPTION
Extract the requested contentful fields for the query calls. To get required fields use `graphql-fields` library to extract from resolverInfo

https://jira.scentregroup.com/browse/STA-119

Example query would be
```
stores(q:"fields.slug=t2") {
    slug
    hideAt
    tradingHours {
      opening_time
      date
    }
    reviews {
      numberTotalReviews
    }
  }
```

For the above we will only get required fields `slug, hideAt, centre, legacyIdentifier, reputationCode`

Will look at doing something similar for `getMany` calls, however, this is using some caching with `dataloader` that may break things there