### PR TITLE
SPIKE: Select fields for contentful items

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash.camelcase": "^4.3.0",
     "lodash.chunk": "^4.2.0",
     "lodash.get": "^4.4.2",
+    "lodash.uniq": "^4.5.0",
     "lodash.upperfirst": "^4.3.1",
     "node-fetch": "^1.7.3",
     "pluralize": "^7.0.0"

--- a/src/entry-loader.js
+++ b/src/entry-loader.js
@@ -158,9 +158,10 @@ function createEntryLoader (http) {
   }
 
   // TODO: Get only required fields here too
-  function getOne (id, forcedCtId) {
-    console.log('getOne', id)
-    return loader.load(id)
+  function getOne (id, forcedCtId, info) {
+    console.log('getOne', id, info && getSelectedFields(info))
+    const selectedFields = forcedCtId && getSelectedFields(info);
+    return loader.load(`${id}${selectedFields ? `&&${forcedCtId}&&${selectedFields}` : ''}`)
     .then(res => {
       const ctId = _get(res, ['sys', 'contentType', 'sys', 'id']);
       if (forcedCtId && ctId !== forcedCtId) {

--- a/src/entry-loader.js
+++ b/src/entry-loader.js
@@ -28,7 +28,7 @@ const getSelectedFields = info => {
     // There is a limit to the number of fields we can select. If too many get everything
     return null;
   }
-  const contentfulFields = topLevelFields.map(fieldKey => `fields.${fieldKey}`).join(',');
+  const contentfulFields = topLevelFields.map(fieldKey => `fields.${fieldKey}`).sort().join(',');
 
   return `sys,${contentfulFields}`;
 };
@@ -97,7 +97,7 @@ function createEntryLoader (http) {
 
   function getMany(ids, forcedCtId, info) {
     console.log('get many', ids)
-    const selectedFields = getSelectedFields(info);
+    const selectedFields = forcedCtId && getSelectedFields(info);
     const idInfoList = ids.map(id => `${id}${selectedFields ? `&&${forcedCtId}&&${selectedFields}` : ''}`)
     console.log('id info list', idInfoList)
 

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -75,7 +75,6 @@ function createEntryFieldConfig (field, ctIdToType) {
   return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx, info) => {
     const linkedId = getLinkedId(link);
     if (isString(linkedId)) {
-      console.log('getOne from field config!!!!!!!!!!!!!!!!!!!!!!!!!!!')
       return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0], info);
     }
   });
@@ -87,7 +86,6 @@ function createArrayOfEntriesFieldConfig (field, ctIdToType) {
   return createFieldConfig(Type, field, (links, ctx, info) => {
     if (Array.isArray(links)) {
       const ids = links.map(getLinkedId).filter(isString);
-      console.log('getMany from field config ++++++++++++++++++++++++++++++++', Type, field.linkedCts[0]);
       return ctx.entryLoader.getMany(ids, field.linkedCts && field.linkedCts[0], info).then(coll => coll.filter(isObject));
     }
   });

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -83,10 +83,11 @@ function createEntryFieldConfig (field, ctIdToType) {
 function createArrayOfEntriesFieldConfig (field, ctIdToType) {
   const Type = new GraphQLList(typeFor(field, ctIdToType));
 
-  return createFieldConfig(Type, field, (links, ctx) => {
+  return createFieldConfig(Type, field, (links, ctx, info) => {
     if (Array.isArray(links)) {
       const ids = links.map(getLinkedId).filter(isString);
-      return ctx.entryLoader.getMany(ids).then(coll => coll.filter(isObject));
+      console.log('getMany from field config ++++++++++++++++++++++++++++++++', Type, field.linkedCts[0]);
+      return ctx.entryLoader.getMany(ids, field.linkedCts && field.linkedCts[0], info).then(coll => coll.filter(isObject));
     }
   });
 }

--- a/src/field-config.js
+++ b/src/field-config.js
@@ -72,10 +72,11 @@ function getAsset (link, ctx) {
 }
 
 function createEntryFieldConfig (field, ctIdToType) {
-  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx) => {
+  return createFieldConfig(typeFor(field, ctIdToType), field, (link, ctx, info) => {
     const linkedId = getLinkedId(link);
     if (isString(linkedId)) {
-      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0]);
+      console.log('getOne from field config!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+      return ctx.entryLoader.get(linkedId, field.linkedCts && field.linkedCts[0], info);
     }
   });
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -64,7 +64,7 @@ function createQueryFields (spaceGraph) {
     acc[ct.names.field] = {
       type: Type,
       args: {id: {type: IDType}},
-      resolve: (_, args, ctx) => ctx.entryLoader.get(args.id, ct.id)
+      resolve: (_, args, ctx, info) => ctx.entryLoader.get(args.id, ct.id, info)
     };
 
     acc[ct.names.collectionField] = {

--- a/src/schema.js
+++ b/src/schema.js
@@ -78,7 +78,7 @@ function createQueryFields (spaceGraph) {
       resolve: (_, args, ctx, info) => {
         const {ids} = args;
         if (ids) {
-          return ctx.entryLoader.getMany(ids, info)
+          return ctx.entryLoader.getMany(ids, ct.id, info)
           .then(objs => objs.filter(obj => obj && obj.sys.contentType.sys.id === ct.id))
         } else {
           return ctx.entryLoader.query(ct.id, args, info);


### PR DESCRIPTION
Implements contentful selection only of requested fields
Uses caching logic for query to ensure that minimum number of calls to contentful are performed

TODO: 
* [ ] Wiki page to describe implementation and test queries
* [ ] Fix unit tests
* [ ] Discard this and revert other changes via #8 
