### PR TITLE
chore(environments): add environment support

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -26,6 +26,7 @@ function createClient (config) {
 function createContentfulClient (api, config) {
   const protocol = config.secure !== false ? 'https' : 'http';
   const domain = config.domain || 'contentful.com';
+  const environmentId = config.environmentId || 'master';
 
   const token = {
     [CDA]: config.cdaToken,
@@ -39,7 +40,7 @@ function createContentfulClient (api, config) {
   }
 
   return createHttpClient({
-    base: `${protocol}://${api}.${domain}/spaces/${config.spaceId}`,
+    base: `${protocol}://${api}.${domain}/spaces/${config.spaceId}/environments/${environmentId}`,
     headers: {Authorization: `Bearer ${token}`},
     defaultParams
   });


### PR DESCRIPTION
Adding backwards compatible environment support to allow for devs to
utilise environments in Contentful.

Motivated by setting up a feature stack for Stackla work.

Consideration: SHOULD be backwards compatible based on all spaces in
Contentful defaulting to having a master environment.